### PR TITLE
Release 1.0.3 fix purpose-event-consumer

### DIFF
--- a/commons/att/images.yaml
+++ b/commons/att/images.yaml
@@ -9,7 +9,7 @@ images:
     pull-signal:
       tag: "1.0.4"
     purpose-event-consumer:
-      tag: "1.0.4"
+      tag: "1.0.5"
     push-signal:
       tag: "1.0.4"
     redis:

--- a/commons/prod/images.yaml
+++ b/commons/prod/images.yaml
@@ -9,7 +9,7 @@ images:
     pull-signal:
       tag: "1.0.4"
     purpose-event-consumer:
-      tag: "1.0.4"
+      tag: "1.0.5"
     push-signal:
       tag: "1.0.4"
     redis:

--- a/commons/uat/images.yaml
+++ b/commons/uat/images.yaml
@@ -9,7 +9,7 @@ images:
     pull-signal:
       tag: "1.0.4-RC1"
     purpose-event-consumer:
-      tag: "1.0.4-RC1"
+      tag: "1.0.5-RC1"
     push-signal:
       tag: "1.0.4-RC1"
     redis:

--- a/commons/vapt/images.yaml
+++ b/commons/vapt/images.yaml
@@ -9,7 +9,7 @@ images:
     pull-signal:
       tag: "1.0.4"
     purpose-event-consumer:
-      tag: "1.0.4"
+      tag: "1.0.5"
     push-signal:
       tag: "1.0.4"
     redis:


### PR DESCRIPTION
 [PIN-6366](https://github.com/pagopa/interop-signalhub-core/pull/204) Fix purpose consumer on PurposeDeletedByRevokedDelegation

[PIN-6366]: https://pagopa.atlassian.net/browse/PIN-6366?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ